### PR TITLE
Add mockery listener to phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,7 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+    <listeners>
+        <listener class="Mockery\Adapter\Phpunit\TestListener" file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
For mockery tests to fail properly when expectations aren't met, this phpunit listener is needed. See: https://github.com/padraic/mockery#phpunit-integration
