### PR TITLE
Fixed broken inheritance

### DIFF
--- a/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
@@ -14,7 +14,7 @@ namespace Omnipay\PayPal\Message;
 /**
  * PayPal Express Complete Authorize Request
  */
-class ExpressCompleteAuthorizeRequest extends AuthorizeRequest
+class ExpressCompleteAuthorizeRequest extends AbstractRequest
 {
     protected $action = 'Authorization';
 


### PR DESCRIPTION
ExpressCompleteAuthorizeRequest was extending AuthorizeRequest which was causing problems as there is no AuthorizeRequest inside of the same namespace. I've fixed it by changing it to inherit from AbstractRequest instead, although I'm not 100% sure thats right.
