### PR TITLE
PayPal ProGateway purchase call fix

### DIFF
--- a/src/Omnipay/PayPal/ProGateway.php
+++ b/src/Omnipay/PayPal/ProGateway.php
@@ -73,7 +73,7 @@ class ProGateway extends AbstractGateway
 
     public function purchase(array $parameters = array())
     {
-        return $this->createRequest('\Omnipay\PayPal\Message\ProAuthorizeRequest', $parameters);
+        return $this->createRequest('\Omnipay\PayPal\Message\ProPurchaseRequest', $parameters);
     }
 
     public function capture(array $parameters = array())


### PR DESCRIPTION
was creating a ProAuthorizeRequest instead of a ProPurchaseRequest
