### PR TITLE
AbstractRequest setAmount typecast change

### DIFF
--- a/src/Omnipay/Common/Message/AbstractRequest.php
+++ b/src/Omnipay/Common/Message/AbstractRequest.php
@@ -168,7 +168,7 @@ abstract class AbstractRequest implements RequestInterface
 
     public function setAmount($value)
     {
-        return $this->setParameter('amount', (int) $value);
+        return $this->setParameter('amount', (float) $value);
     }
 
     public function getAmountDecimal()


### PR DESCRIPTION
The setAmount method within Omnipay\Common\Message\AbstractRequest converts the amount to an integer by default, which causes a loss of data when trying to charge amounts using decimal places.

I've made this change to cast to float instead. I can't imagine any detrimental effects on backwards compatibility, but if you think of anything, do flag it up and I'll address it.
