### PR TITLE
Get additional transaction info

### DIFF
--- a/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressCompleteAuthorizeRequest.php
@@ -35,4 +35,27 @@ class ExpressCompleteAuthorizeRequest extends AbstractRequest
 
         return $data;
     }
+
+    public function getDetailsData()
+    {
+        $data = $this->getBaseData('GetExpressCheckoutDetails');
+
+        $data['TOKEN'] = $this->httpRequest->query->get('token');
+        $data['PAYERID'] = $this->httpRequest->query->get('PayerID');
+
+        return $data;
+    }
+
+    public function send()
+    {
+        $paymentDoResponse = parent::send();
+
+        $url = $this->getEndpoint().'?'.http_build_query($this->getDetailsData());
+        $httpResponse = $this->httpClient->get($url)->send();
+        $paymentInfoResponse =  $this->createResponse($httpResponse->getBody());
+
+        $mergedData = array_merge($paymentDoResponse->getData(), $paymentInfoResponse->getData());
+
+        return $this->createResponse(http_build_query($mergedData));
+    }
 }


### PR DESCRIPTION
ExpressCompleteAuthorizeRequest::send() doesn't return some info. For example INVNUM.
Is very important to get transaction id in response.
I tryed to call GetExpressCheckoutDetails after DoExpressCheckoutPayment. But that doesn't return another info like fee. So I have merged data of two responses. 

Please check.  
