### PR TITLE
PayPal partial refund support

### DIFF
--- a/src/Omnipay/PayPal/Message/RefundRequest.php
+++ b/src/Omnipay/PayPal/Message/RefundRequest.php
@@ -16,16 +16,6 @@ namespace Omnipay\PayPal\Message;
  */
 class RefundRequest extends AbstractRequest
 {
-    public function getRefundType()
-    {
-        return $this->getParameter('refundType') ?: 'Full';
-    }
-
-    public function setRefundType($value)
-    {
-        return $this->setParameter('refundType', $value);
-    }
-
     public function getData()
     {
         $data = $this->getBaseData('RefundTransaction');
@@ -33,8 +23,9 @@ class RefundRequest extends AbstractRequest
         $this->validate('transactionReference');
 
         $data['TRANSACTIONID'] = $this->getTransactionReference();
-        $data['REFUNDTYPE'] = $this->getRefundType();
-        if ($this->getRefundType() != 'Full') {
+        $data['REFUNDTYPE'] = 'Full';
+        if ($this->getAmountDecimal() > 0) {
+            $data['REFUNDTYPE'] = 'Partial';
             $data['AMT'] = $this->getAmountDecimal();
             $data['CURRENCYCODE'] = $this->getCurrency();
         }


### PR DESCRIPTION
If no redundType is specified it will default to Full for backwards compatibility. According to PayPal [documentation](https://cms.paypal.com/uk/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_nvp_r_RefundTransaction) AMT (and CURRENCYCODE) should only be provided if REFUNDTYPE isn't Full.
