### PR TITLE
Added Header Image Support

### DIFF
--- a/src/Omnipay/PayPal/ExpressGateway.php
+++ b/src/Omnipay/PayPal/ExpressGateway.php
@@ -64,16 +64,6 @@ class ExpressGateway extends ProGateway
         return $this->setParameter('landingPage', $value);
     }
 
-    public function getHeaderImage()
-    {
-        return $this->getParameter('headerImage');
-    }
-
-    public function setHeaderImage($value)
-    {
-        return $this->setParameter('headerImage', $value);
-    }
-
     public function authorize(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PayPal\Message\ExpressAuthorizeRequest', $parameters);

--- a/src/Omnipay/PayPal/Message/AbstractRequest.php
+++ b/src/Omnipay/PayPal/Message/AbstractRequest.php
@@ -69,6 +69,16 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('landingPage', $value);
     }
 
+    public function getHeaderImage()
+    {
+        return $this->getParameter('headerImage');
+    }
+
+    public function setHeaderImage($value)
+    {
+        return $this->setParameter('headerImage', $value);
+    }
+
     protected function getBaseData($method)
     {
         $data = array();

--- a/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
+++ b/src/Omnipay/PayPal/Message/ExpressAuthorizeRequest.php
@@ -60,4 +60,15 @@ class ExpressAuthorizeRequest extends AbstractRequest
     {
         return $this->response = new ExpressAuthorizeResponse($this, $data);
     }
+
+    public function getHeaderImage()
+    {
+        return $this->getParameter('headerImage');
+    }
+
+    public function setHeaderImage($value)
+    {
+        return $this->setParameter('headerImage', $value);
+    }
+
 }


### PR DESCRIPTION
added Header Image support to PayPal Express Gateway. Supply a link to an image upto 750px x 90px to display using checkout process
