### PR TITLE
Add Mollie iDeal gateway

### DIFF
--- a/src/Omnipay/Mollie/Message/AbstractRequest.php
+++ b/src/Omnipay/Mollie/Message/AbstractRequest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+/**
+ * Mollie iDeal Abstract Request
+ */
+abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
+{
+    protected $endpoint = 'https://secure.mollie.nl/xml/ideal';
+
+    /**
+     * More permissive testMode check.
+     * @return bool
+     */
+    public function getTestMode() {
+        return (in_array(strtolower(parent::getTestMode()), array('yes', '1', 'true')));
+    }
+
+    /**
+     * Does the actual response generation / sending.
+     * @return Response
+     */
+    public function send()
+    {
+        $url = $this->getEndpoint().'?'.http_build_query($this->getData());
+        $request = $this->httpClient->get($url);
+        $httpResponse = $request->send();
+        return $this->createResponse($httpResponse);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEndpoint()
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * @param $data
+     *
+     * @return Response
+     */
+    protected function createResponse($data)
+    {
+        return $this->response = new Response($this, $data);
+    }
+
+    /**
+     * Gets the partner_id parameter
+     * @return mixed
+     */
+    public function getPartnerId()
+    {
+        return $this->getParameter('partner_id');
+    }
+
+    /**
+     * Sets the partner_id parameter
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setPartnerId($value)
+    {
+        return $this->setParameter('partner_id', $value);
+    }
+
+    /**
+     * Get the bank_id parameter
+     *
+     * @return mixed
+     */
+    public function getBankId()
+    {
+        return $this->getParameter('bank_id');
+    }
+
+    /**
+     * Sets the bank_id parameter
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setBankId($value)
+    {
+        return $this->setParameter('bank_id', $value);
+    }
+
+    /**
+     * Gets the profile_key parameter
+     *
+     * @return mixed
+     */
+    public function getProfileKey()
+    {
+        return $this->getParameter('profile_key');
+    }
+
+    /**
+     * Sets the profile_key parameter
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setProfileKey($value)
+    {
+        return $this->setParameter('profile_key', $value);
+    }
+
+    /**
+     * Gets the reportUrl parameter
+     *
+     * @return mixed
+     */
+    public function getReportUrl()
+    {
+        return $this->getParameter('reportUrl');
+    }
+
+    /**
+     * Sets the reportUrl parameter.
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setReportUrl($value)
+    {
+        return $this->setParameter('reportUrl', $value);
+    }
+}

--- a/src/Omnipay/Mollie/Message/Response.php
+++ b/src/Omnipay/Mollie/Message/Response.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
+
+/**
+ * Mollie Response
+ */
+class Response extends AbstractResponse
+{
+    /**
+     * Creates a new Response instance, parsing the request data from XML.
+     *
+     * @param RequestInterface $request
+     * @param $data
+     */
+    public function __construct(RequestInterface $request, $data)
+    {
+        $this->request = $request;
+        $this->data = $data->xml();
+    }
+
+    /**
+     * We consider the general response successful if the data is a SimpleXMLElement.
+     *
+     * @return boolean
+     */
+    public function isSuccessful()
+    {
+        return ($this->data instanceof \SimpleXMLElement);
+    }
+
+    /**
+     * Default redirect method for Mollie iDeal.
+     *
+     * @return string
+     */
+    public function getRedirectMethod()
+    {
+        return 'GET';
+    }
+
+    /**
+     * Default redirect data for Mollie iDeal (none).
+     *
+     * @return null
+     */
+    public function getRedirectData()
+    {
+        return null;
+    }
+
+    /**
+     * Gets the transaction_id from the order, if available.
+     *
+     * @return string|null
+     */
+    public function getTransactionReference()
+    {
+        if ($this->data instanceof \SimpleXMLElement
+            && $this->data->order instanceof \SimpleXMLElement
+            && $this->data->order->transaction_id
+        ) {
+            return (string)$this->data->order->transaction_id;
+        }
+        return null;
+    }
+
+
+    /**
+     * Gets the message from the request. Mollie iDeal has a message in most APIs,
+     * so don't check for this to see if it was successful or not.
+     *
+     * @return null|string
+     */
+    public function getMessage()
+    {
+        if ($this->data instanceof \SimpleXMLElement) {
+            if ($this->data->item && $this->data->item->message) return (string)$this->data->item->message;
+            if ($this->data->order && $this->data->order->message) return (string)$this->data->order->message;
+            if ($this->data->message) return (string)$this->data->message;
+        }
+        return null;
+    }
+}

--- a/src/Omnipay/Mollie/Message/iDealAuthorizeRequest.php
+++ b/src/Omnipay/Mollie/Message/iDealAuthorizeRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+/**
+ * Mollie Express Authorize Request
+ */
+class iDealAuthorizeRequest extends AbstractRequest
+{
+    protected function createResponse($data)
+    {
+        return $this->response = new iDealAuthorizeResponse($this, $data);
+    }
+
+    /**
+     * Get the data for this request. See documentation at
+     * https://www.mollie.nl/beheer/betaaldiensten/documentatie/ideal/
+     *
+     * @return mixed
+     */
+    public function getData() {
+        $data = array(
+            'a' => 'fetch',
+            'partnerid' => $this->getPartnerId(),
+            'amount' => $this->getAmount(),
+            'bank_id' => str_pad($this->httpRequest->request->get('bank_id'), 4, '0', STR_PAD_LEFT),
+            'description' => $this->getDescription(),
+            'reporturl' => $this->getReportUrl(),
+            'returnurl' => $this->getReturnUrl(),
+            'profile_key' => $this->getProfileKey(),
+        );
+        if ($this->getTestMode()) {
+            $data['testmode'] = 'true';
+        }
+        return $data;
+    }
+}

--- a/src/Omnipay/Mollie/Message/iDealAuthorizeResponse.php
+++ b/src/Omnipay/Mollie/Message/iDealAuthorizeResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+use Omnipay\Common\Message\RedirectResponseInterface;
+
+/**
+ * Mollie iDeal Express Authorize Response
+ */
+class iDealAuthorizeResponse extends Response implements RedirectResponseInterface
+{
+    /**
+     * By definition it wont be succesful - it will need the redirect.
+     * @return bool
+     */
+    public function isSuccessful()
+    {
+        return false;
+    }
+
+    /**
+     * It only is a redirect if the url is valid/exists.
+     * @return bool
+     */
+    public function isRedirect()
+    {
+        if ($this->getRedirectUrl()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the URL from the redirect.
+     *
+     * @return null|string
+     */
+    public function getRedirectUrl()
+    {
+        if ($this->data instanceof \SimpleXMLElement
+            && isset($this->data->order)
+            && isset($this->data->order->URL)
+        ) {
+            return (string)$this->data->order->URL;
+        }
+        return null;
+    }
+}

--- a/src/Omnipay/Mollie/Message/iDealBanklistRequest.php
+++ b/src/Omnipay/Mollie/Message/iDealBanklistRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+/**
+ * Mollie iDeal Banklist Authorize Request
+ */
+class iDealBanklistRequest extends AbstractRequest
+{
+    /**
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        $data = array(
+            'a' => 'banklist',
+        );
+
+        if ($this->getTestMode()) {
+            $data['testmode'] = 'true';
+        }
+
+        return $data;
+    }
+
+    protected function createResponse($httpResponse)
+    {
+        return $this->response = new iDealBanklistResponse($this, $httpResponse);
+    }
+}

--- a/src/Omnipay/Mollie/Message/iDealBanklistResponse.php
+++ b/src/Omnipay/Mollie/Message/iDealBanklistResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+use Omnipay\Common\Message\ResponseInterface;
+
+/**
+ * Mollie iDeal Banklist Response
+ */
+class iDealBanklistResponse extends Response implements ResponseInterface
+{
+}

--- a/src/Omnipay/Mollie/Message/iDealCompleteAuthorizeRequest.php
+++ b/src/Omnipay/Mollie/Message/iDealCompleteAuthorizeRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+/**
+ * Mollie Express Authorize Request
+ */
+class iDealCompleteAuthorizeRequest extends AbstractRequest
+{
+    /**
+     * @param $data
+     *
+     * @return iDealCompleteAuthorizeResponse
+     */
+    protected function createResponse($data)
+    {
+        return $this->response = new iDealCompleteAuthorizeResponse($this, $data);
+    }
+
+    /**
+     * Get the data array for this message. For Mollie's iDeal gateway, this is
+     * an array.
+     *
+     * @return array
+     */
+    public function getData() {
+        $data = array(
+            'a' => 'check',
+            'partnerid' => $this->getPartnerId(),
+            'transaction_id' => $this->httpRequest->query->get('transaction_id'),
+        );
+        if ($this->getTestMode()) {
+            $data['testmode'] = 'true';
+        }
+        return $data;
+    }
+}

--- a/src/Omnipay/Mollie/Message/iDealCompleteAuthorizeResponse.php
+++ b/src/Omnipay/Mollie/Message/iDealCompleteAuthorizeResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie\Message;
+
+/**
+ * Mollie iDeal Express Authorize Response
+ */
+class iDealCompleteAuthorizeResponse extends Response
+{
+    /**
+     * Checks if the iDeal payment was successfully paid.
+     * Note that this only returns true if the "payed=true" flag is set in the
+     * returned XML, which Mollie only returns once.
+     *
+     * @return bool
+     */
+    public function isSuccessful()
+    {
+        if ($this->data instanceof \SimpleXMLElement
+            && isset($this->data->order)
+            && isset($this->data->order->payed)
+            && (string)$this->data->order->payed == 'true'
+            ) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Omnipay/Mollie/iDealGateway.php
+++ b/src/Omnipay/Mollie/iDealGateway.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Omnipay package.
+ *
+ * (c) Adrian Macneil <adrian@adrianmacneil.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Omnipay\Mollie;
+
+use Omnipay\Common\AbstractGateway;
+use Omnipay\Mollie\Message\ProAuthorizeRequest;
+use Omnipay\Mollie\Message\CaptureRequest;
+use Omnipay\Mollie\Message\RefundRequest;
+
+/**
+ * Mollie Pro Class
+ */
+class iDealGateway extends AbstractGateway
+{
+    /**
+     * Name of this gateway: Mollie iDeal.
+     *
+     * Could have been "iDeal" but it's probably at some point other iDeal gateways will be
+     * available, like Sisow. Mollie also offers other payment methods besides iDeal.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Mollie iDeal';
+    }
+
+    /**
+     * Parameters for this gateway.
+     *
+     * @return array
+     */
+    public function getDefaultParameters()
+    {
+        return array(
+            'partnerid' => '',
+            'profile_key' => '',
+            'bank_id' => 0,
+            'testMode' => false,
+        );
+    }
+
+    /**
+     * Authorizes a payment. In the case of Mollie iDeal, this means it creates a transaction
+     * record and returns a Redirect Response.
+     *
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function authorize(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Mollie\Message\iDealAuthorizeRequest', $parameters);
+    }
+
+    /**
+     * Validates the iDeal payment based on a $_GET['transaction_id'] provided by Mollie.
+     *
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function completeAuthorize(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Mollie\Message\iDealCompleteAuthorizeRequest', $parameters);
+    }
+
+    /**
+     * @see self::authorize
+     *
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function purchase(array $parameters = array())
+    {
+        return $this->authorize($parameters);
+    }
+
+    /**
+     * @see self::completeAuthorize
+     *
+     * @param array $parameters
+     *
+     * @return mixed
+     */
+    public function completePurchase(array $parameters = array())
+    {
+        return $this->completeAuthorize($parameters);
+    }
+
+    /**
+     * Gets an associative array of bank IDs and their name from iDeal.
+     * This respects testMode and will return a special test bank only
+     * if testMode is enabled. If you implement caching, make sure to
+     * keep that in mind.
+     *
+     * @return array
+     */
+    public function getBanks()
+    {
+        $banks = array();
+        /** @var \Omnipay\Mollie\Message\iDealBanklistRequest $request */
+        $request = $this->createRequest('\Omnipay\Mollie\Message\iDealBanklistRequest', array());
+        if ($request) {
+            $response = $request->send();
+            if ($response) {
+                $data = $response->getData();
+                foreach ($data->bank as $bank) {
+                    $banks[(string)$bank->bank_id] = (string)$bank->bank_name;
+                }
+            }
+        }
+
+        return $banks;
+    }
+}


### PR DESCRIPTION
Hi Adrian!

This PR implements Mollie's iDeal API (https://www.mollie.nl/support/documentatie/betaaldiensten/ideal). iDeal is the de-facto Dutch payment method with Mollie being one of two (Sisow being the other) intermediate gateways that I think are most used. 

I've not yet implemented tests (something about trying to launch a business and hurry hurry) - feel free to decline if it's a dealbreaker, no hard feelings. That said, if you have any feedback in the interim, please do let me know.
