### PR TITLE
Resolved an issue when trying to create a redirect response which uses POST data.

### DIFF
--- a/src/Omnipay/Common/Message/AbstractResponse.php
+++ b/src/Omnipay/Common/Message/AbstractResponse.php
@@ -100,7 +100,7 @@ abstract class AbstractResponse implements ResponseInterface
         </form>
     </body>
 </html>';
-            $output = sprintf($output, htmlspecialchars($this->redirectUrl, ENT_QUOTES, 'UTF-8'), $hiddenFields);
+            $output = sprintf($output, htmlspecialchars($this->getRedirectUrl(), ENT_QUOTES, 'UTF-8'), $hiddenFields);
 
             HttpResponse::create($output)->send();
             exit;


### PR DESCRIPTION
The AbstractResponse class in Omnipay/Common/Message currently references $this->redirectUrl which does not exist.

This should instead reference $this->getRedirectUrl()
