### PR TITLE
SagePay uses shorthand type names for Mastercard and Diners Club

### DIFF
--- a/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
+++ b/src/Omnipay/SagePay/Message/DirectAuthorizeRequest.php
@@ -62,11 +62,23 @@ class DirectAuthorizeRequest extends AbstractRequest
         $data = $this->getBaseAuthorizeData();
         $this->getCard()->validate();
 
+        $cardType = $this->getCard()->getBrand();
+
+        // list of brands SagePay names differently
+        $brands = array(
+            'mastercard' => 'mc',
+            'diners_club' => 'dc'
+        );
+
+        if (isset($brands[$cardType])) {
+            $cardType = $brands[$cardType];
+        }
+
         $data['CardHolder'] = $this->getCard()->getName();
         $data['CardNumber'] = $this->getCard()->getNumber();
         $data['CV2'] = $this->getCard()->getCvv();
         $data['ExpiryDate'] = $this->getCard()->getExpiryDate('my');
-        $data['CardType'] = $this->getCard()->getBrand();
+        $data['CardType'] = $cardType;
 
         if ($this->getCard()->getStartMonth() and $this->getCard()->getStartYear()) {
             $data['StartDate'] = $this->getCard()->getStartDate('my');


### PR DESCRIPTION
SagePay calls Mastercard 'mc' and Diners Club 'dc' so payments using these methods will fail if passed the full names.
