### PR TITLE
Add support for SagePay ERROR and INVALID responses

### DIFF
--- a/src/Omnipay/SagePay/Message/ServerCompleteAuthorizeResponse.php
+++ b/src/Omnipay/SagePay/Message/ServerCompleteAuthorizeResponse.php
@@ -103,9 +103,9 @@ class ServerCompleteAuthorizeResponse extends Response
      *               return controller action URL.
      * @param string Optional human readable reasons for accepting the transaction.
      */
-    protected function sendResponse($status, $nextUrl, $detail = null)
+    public function sendResponse($status, $nextUrl, $detail = null)
     {
-        $response = "Status=" . $status . "\r\nRedirectUrl=".$nextUrl;
+        $response = "Status=" . $status . "\r\nRedirectUrl=" . $nextUrl;
 
         if ($detail != null) {
             $response .= "\r\nStatusDetail=".$detail;

--- a/tests/Omnipay/SagePay/Message/ServerCompleteAuthorizeResponseTest.php
+++ b/tests/Omnipay/SagePay/Message/ServerCompleteAuthorizeResponseTest.php
@@ -12,6 +12,7 @@
 namespace Omnipay\SagePay\Message;
 
 use Omnipay\TestCase;
+use Mockery as m;
 
 class ServerCompleteAuthorizeResponseTest extends TestCase
 {
@@ -53,5 +54,13 @@ class ServerCompleteAuthorizeResponseTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertNull($response->getMessage());
+    }
+
+    public function testSendResponseConfirm()
+    {
+        $response = m::mock('\Omnipay\SagePay\Message\ServerCompleteAuthorizeResponse[sendResponse]');
+        $response->shouldReceive('sendResponse')->once()->with('OK', 'http://localhost', 'detail');
+
+        $response->confirm('http://localhost', 'detail');
     }
 }


### PR DESCRIPTION
SagePay Server requires the developer to respond to a callback with either an OK, ERROR or INVALID response, a redirect URL and an optional 'detail' field.

This pull request adds support for the ERROR and INVALID responses (OK was already supported), and for the optional 'detail' field.
