### PR TITLE
Update pin gateway to add support for purchasing with card tokens

### DIFF
--- a/src/Omnipay/Pin/Message/PurchaseRequest.php
+++ b/src/Omnipay/Pin/Message/PurchaseRequest.php
@@ -40,8 +40,11 @@ class PurchaseRequest extends AbstractRequest
         $data['currency'] = strtolower($this->getCurrency());
         $data['description'] = $this->getDescription();
         $data['ip_address'] = $this->getClientIp();
+        $data['email'] = $this->getCard()->getEmail();
 
-        if ($this->getCard()) {
+        if ($this->getToken()) {
+            $data['card_token'] = $this->getToken();
+        } elseif ($this->getCard()) {
             $this->getCard()->validate();
 
             $data['card']['number'] = $this->getCard()->getNumber();
@@ -55,7 +58,6 @@ class PurchaseRequest extends AbstractRequest
             $data['card']['address_postcode'] = $this->getCard()->getPostcode();
             $data['card']['address_state'] = $this->getCard()->getState();
             $data['card']['address_country'] = $this->getCard()->getCountry();
-            $data['email'] = $this->getCard()->getEmail();
         }
 
         return $data;

--- a/tests/Omnipay/Pin/Message/PurchaseRequestTest.php
+++ b/tests/Omnipay/Pin/Message/PurchaseRequestTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Omnipay\Pin\Message;
+
+use Omnipay\TestCase;
+
+class PurchaseRequestTest extends TestCase
+{
+  public function setUp()
+  {
+    $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+    $this->request->initialize(
+      array(
+        'amount' => '10.00',
+        'currency' => 'AUD',
+        'card' => $this->getValidCard(),
+      )
+    );
+  }
+
+  public function testDataWithToken()
+  {
+    $this->request->setToken('abc');
+    $data = $this->request->getData();
+
+    $this->assertSame('abc', $data['card_token']);
+  }
+
+  public function testDataWithCard()
+  {
+    $card = $this->getValidCard();
+    $this->request->setCard($card);
+    $data = $this->request->getData();
+
+    $this->assertSame($card['number'], $data['card']['number']);
+  }
+
+  public function testSendSuccess()
+  {
+    $this->setMockHttpResponse('PurchaseSuccess.txt');
+
+    $response = $this->request->send();
+
+    $this->assertTrue($response->isSuccessful());
+    $this->assertFalse($response->isRedirect());
+    $this->assertEquals('ch_fXIxWf0gj1yFHJcV1W-d-w', $response->getTransactionReference());
+    $this->assertSame('Success!', $response->getMessage());
+  }
+
+  public function testSendError()
+  {
+    $this->setMockHttpResponse('PurchaseFailure.txt');
+    $response = $this->request->send();
+
+    $this->assertFalse($response->isSuccessful());
+    $this->assertFalse($response->isRedirect());
+    $this->assertNull($response->getTransactionReference());
+    $this->assertSame('The current resource was deemed invalid.', $response->getMessage());
+  }
+}


### PR DESCRIPTION
I don't normally write PHP so this may be terrible, but I gave it a shot.

The example looks a bit weird as the email is still required, but is an attribute of the card with Omnipay? So it looks like this:

``` php
$gateway = GatewayFactory::create('Pin');
$gateway->setSecretKey('secret-key');

$response = $gateway->purchase([
  'description' => 'Widgets',
  'amount'      => '1.21',
  'currency'    => 'USD',
  'token'  => 'card_mcqQ_H1NtRODN1reRwEdmQ',
  'ip_address'  => '1.2.3.4',
  'card' => array('email' => 'test@example.org'),
])->send();
```
