### PR TITLE
Add MultiSafepay to composer.json keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "merchant",
         "migs",
         "mollie",
+        "multisafepay",
         "netaxept",
         "netbanx",
         "pay",


### PR DESCRIPTION
This was actually forgotten when MultiSafepay was added. (And I noticed in https://github.com/adrianmacneil/omnipay/commit/9491b2bd0dc87e764b2525b84cb0a8d0ae39f100 that this is done for new gateways.)
