### PR TITLE
Add branch-alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,5 +65,10 @@
         "silex/silex": "1.0.*@dev",
         "squizlabs/php_codesniffer": "~1.4.4",
         "twig/twig": "~1.12"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This will show 1.0.x-dev as default on packagist, as an alias for dev-master. This will allow specifying 1.0.\* in composer.json, and depending on minimum-stability, either the latest stable or dev-master will be installed.
