### PR TITLE
Add forgotten purchase parameter to MultiSafepay gateway

### DIFF
--- a/src/Omnipay/MultiSafepay/Message/PurchaseRequest.php
+++ b/src/Omnipay/MultiSafepay/Message/PurchaseRequest.php
@@ -86,6 +86,16 @@ class PurchaseRequest extends AbstractRequest
         return $this->setParameter('extraData3', $value);
     }
 
+    public function getItems()
+    {
+        return $this->getParameter('items');
+    }
+
+    public function setItems($value)
+    {
+        return $this->setParameter('items', $value);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -135,6 +145,7 @@ class PurchaseRequest extends AbstractRequest
         $transaction->addChild('var1', $this->getExtraData1());
         $transaction->addChild('var2', $this->getExtraData2());
         $transaction->addChild('var3', $this->getExtraData3());
+        $transaction->addChild('items', $this->getItems());
 
         $data->addChild('signature', $this->generateSignature());
 

--- a/tests/Omnipay/MultiSafepay/Message/PurchaseRequestTest.php
+++ b/tests/Omnipay/MultiSafepay/Message/PurchaseRequestTest.php
@@ -41,6 +41,7 @@ class PurchaseRequestTest extends TestCase
             'extraData2' => 'extra 2',
             'extraData3' => 'extra 3',
             'language' => 'a language',
+            'items' => 'the items',
             'clientIp' => '127.0.0.1',
             'googleAnalyticsCode' => 'analytics code',
             'card' => array(
@@ -177,6 +178,7 @@ class PurchaseRequestTest extends TestCase
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
+    <items>the items</items>
   </transaction>
   <signature>ad447bab87b8597853432c891e341db1</signature>
 </redirecttransaction>
@@ -224,6 +226,7 @@ EOF;
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
+    <items>the items</items>
   </transaction>
   <signature>ad447bab87b8597853432c891e341db1</signature>
 </redirecttransaction>
@@ -274,6 +277,7 @@ EOF;
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
+    <items>the items</items>
   </transaction>
   <signature>ad447bab87b8597853432c891e341db1</signature>
 </redirecttransaction>


### PR DESCRIPTION
I forgot the `items` parameter when I initially implemented MultiSafepay, this adds it.
