### PR TITLE
Authorize.net AVS Match and Auth Code

### DIFF
--- a/src/Omnipay/AuthorizeNet/Message/AIMResponse.php
+++ b/src/Omnipay/AuthorizeNet/Message/AIMResponse.php
@@ -44,4 +44,14 @@ class AIMResponse extends AbstractResponse
     {
         return $this->data[3];
     }
+
+    public function getAuthorizeCode()
+    {
+        return $this->data[4];
+    }
+
+    public function getAVSMatch()
+    {
+        return $this->data[5];
+    }
 }


### PR DESCRIPTION
Added two methods to get useful data, AVS Match and the Authorize Code, from an Authorize.Net AIM response
