### PR TITLE
MultiSafepay: Fixed wrong gateway node and added support for direct transactions

### DIFF
--- a/src/Omnipay/MultiSafepay/Message/PurchaseResponse.php
+++ b/src/Omnipay/MultiSafepay/Message/PurchaseResponse.php
@@ -27,7 +27,7 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
      */
     public function isRedirect()
     {
-        return isset($this->data->transaction->payment_url);
+        return isset($this->data->transaction->payment_url) || isset($this->data->gatewayinfo->redirecturl);
     }
 
     /**
@@ -35,7 +35,13 @@ class PurchaseResponse extends AbstractResponse implements RedirectResponseInter
      */
     public function getRedirectUrl()
     {
-        return $this->isRedirect() ? (string) $this->data->transaction->payment_url : null;
+        if (isset($this->data->gatewayinfo->redirecturl)) {
+            return (string) $this->data->gatewayinfo->redirecturl;
+        } elseif (isset($this->data->transaction->payment_url)) {
+            return (string) $this->data->transaction->payment_url;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Omnipay/MultiSafepay/Message/PurchaseRequestTest.php
+++ b/tests/Omnipay/MultiSafepay/Message/PurchaseRequestTest.php
@@ -134,7 +134,7 @@ class PurchaseRequestTest extends TestCase
     {
         $xml = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<redirecttransaction ua="Omnipay">
+<directtransaction ua="Omnipay">
   <merchant>
     <account>111111</account>
     <site_id>222222</site_id>
@@ -142,11 +142,7 @@ class PurchaseRequestTest extends TestCase
     <notification_url>http://localhost/notify</notification_url>
     <cancel_url>http://localhost/cancel</cancel_url>
     <redirect_url>http://localhost/return</redirect_url>
-    <gateway>IDEAL</gateway>
   </merchant>
-  <gatewayinfo>
-    <issuerid>issuer</issuerid>
-  </gatewayinfo>
   <customer>
     <ipaddress>127.0.0.1</ipaddress>
     <locale>a language</locale>
@@ -170,9 +166,13 @@ class PurchaseRequestTest extends TestCase
     <var2>extra 2</var2>
     <var3>extra 3</var3>
     <items>the items</items>
+    <gateway>IDEAL</gateway>
   </transaction>
+  <gatewayinfo>
+    <issuerid>issuer</issuerid>
+  </gatewayinfo>
   <signature>ad447bab87b8597853432c891e341db1</signature>
-</redirecttransaction>
+</directtransaction>
 
 EOF;
 
@@ -193,7 +193,6 @@ EOF;
     <notification_url>http://localhost/notify</notification_url>
     <cancel_url>http://localhost/cancel</cancel_url>
     <redirect_url>http://localhost/return</redirect_url>
-    <gateway>another</gateway>
   </merchant>
   <customer>
     <ipaddress>127.0.0.1</ipaddress>
@@ -218,6 +217,7 @@ EOF;
     <var2>extra 2</var2>
     <var3>extra 3</var3>
     <items>the items</items>
+    <gateway>another</gateway>
   </transaction>
   <signature>ad447bab87b8597853432c891e341db1</signature>
 </redirecttransaction>
@@ -233,7 +233,7 @@ EOF;
     {
         $xml = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<redirecttransaction ua="Omnipay">
+<directtransaction ua="Omnipay">
   <merchant>
     <account>111111</account>
     <site_id>222222</site_id>
@@ -241,11 +241,7 @@ EOF;
     <notification_url>http://localhost/?one=1&amp;two=2</notification_url>
     <cancel_url>http://localhost/?one=1&amp;two=2</cancel_url>
     <redirect_url>http://localhost/?one=1&amp;two=2</redirect_url>
-    <gateway>IDEAL</gateway>
   </merchant>
-  <gatewayinfo>
-    <issuerid>issuer</issuerid>
-  </gatewayinfo>
   <customer>
     <ipaddress>127.0.0.1</ipaddress>
     <locale>a language</locale>
@@ -269,9 +265,13 @@ EOF;
     <var2>extra 2</var2>
     <var3>extra 3</var3>
     <items>the items</items>
+    <gateway>IDEAL</gateway>
   </transaction>
+  <gatewayinfo>
+    <issuerid>issuer</issuerid>
+  </gatewayinfo>
   <signature>ad447bab87b8597853432c891e341db1</signature>
-</redirecttransaction>
+</directtransaction>
 
 EOF;
 


### PR DESCRIPTION
The `<gateway>` element should be part of `<transaction>` instead of `<merchant>`. 

When you use Direct Bank Transfer or Direct Debit or iDEAL with Issuer supplied the plugin will directly redirect you to the bank instead of the MultiSafepay pages.
