### PR TITLE
Adding supportsPurchase method to AbstractGateway

### DIFF
--- a/src/Omnipay/Common/AbstractGateway.php
+++ b/src/Omnipay/Common/AbstractGateway.php
@@ -129,6 +129,16 @@ abstract class AbstractGateway implements GatewayInterface
     {
         return method_exists($this, 'capture');
     }
+    
+    /**
+     * Supports Purchase
+     *
+     * @return boolean True if this gateway supports the purchase() method
+     */
+    public function supportsPurchase()
+    {
+        return method_exists($this, 'purchase');
+    }
 
     /**
      * Supports Complete Purchase


### PR DESCRIPTION
The supports\* methods are really helpful, although it appears as though a method is missing to check if the purchase() method is supported.

This PR adds a supportsPurchase() method to AbstractGateway
