### PR TITLE
Fix Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **An easy to use, consistent payment processing library for PHP 5.3+**
 
-[![Build Status](https://travis-ci.org/omnipay/common.png?branch=master)](https://travis-ci.org/omnipay/common)
+[![Build Status](https://travis-ci.org/omnipay/omnipay.png?branch=master)](https://travis-ci.org/omnipay/omnipay)
 [![Latest Stable Version](https://poser.pugx.org/omnipay/omnipay/version.png)](https://packagist.org/packages/omnipay/omnipay)
 [![Total Downloads](https://poser.pugx.org/omnipay/omnipay/d/total.png)](https://packagist.org/packages/omnipay/omnipay)
 


### PR DESCRIPTION
Travis CI badge is pointing to omnipay/common and it should point to the omnipay/omnipay repository.
