### PR TITLE
Add AGMS Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The following gateways are available:
 Gateway | Composer Package | Maintainer
 --- | --- | ---
 [2Checkout](https://github.com/thephpleague/omnipay-2checkout) | omnipay/2checkout | [Kayla Daniels](https://github.com/kayladnls)
+[Agms](https://github.com/agmscode/omnipay-agms) | agmscode/omnipay-agms | [Maanas Royy](https://github.com/maanas)
 [Alipay](https://github.com/lokielse/omnipay-alipay) | lokielse/omnipay-alipay | [Loki Else](https://github.com/lokielse)
 [Authorize.Net](https://github.com/thephpleague/omnipay-authorizenet) | omnipay/authorizenet | [Kayla Daniels](https://github.com/kayladnls)
 [Barclays ePDQ](https://github.com/samvaughton/omnipay-barclays-epdq) | samvaughton/omnipay-barclays-epdq | [Sam Vaughton](https://github.com/samvaughton)


### PR DESCRIPTION
We're with AGMS, a US-based payments and marketing technology company. Our changes add support for our AGMS Gateway (http://onlinepaymentprocessing.com, http://www.agms.com).

The Agms Omnipay library has passed the travis build test. A version of library has also been released on packagist.org.

We have included a test credentials in the unit tests which do actual test transaction on the gateway.

Please let me know if we miss any thing.

Thank you