### PR TITLE
Php version: End support for php 5.3 for security reasons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
 
 env:
   - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
 
 env:
   - SYMFONY_VERSION="2.1" GUZZLE_VERSION="3.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omnipay
 
-**An easy to use, consistent payment processing library for PHP 5.3+**
+**An easy to use, consistent payment processing library for PHP 5.4+**
 
 [![Build Status](https://travis-ci.org/thephpleague/omnipay-common.png?branch=master)](https://travis-ci.org/thephpleague/omnipay-common)
 [![Latest Stable Version](https://poser.pugx.org/omnipay/omnipay/version.png)](https://packagist.org/packages/omnipay/omnipay)


### PR DESCRIPTION
This is a pull request suggesting removal of support for php 5.3 in this project.
 - Php version 5.3 is past it's End-Of-Life.  It no longer receives security support or updates of any kind.
 - Php version 5.3 is especially problematic in terms of security due to an ecosystem of related security bugs that exist in the older OS versions that use it: huge openssl security bugs and major bcrypt hashing bugs.
 - The doc examples as currently written will fatal error with php 5.3 any more. #290 

So I recommend moving beyond any implied support for php 5.3.  I made the trivial commits atomic so you can cherry-pick if you want.  Will squash the commits upon request.

The travis build passes for the added php 5.6 and php 7 versions.