### PR TITLE
Replace Wechat with WechatPay

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Gateway | Composer Package | Maintainer
 [Stripe](https://github.com/thephpleague/omnipay-stripe) | omnipay/stripe | [Kayla Daniels](https://github.com/kayladnls)
 [TargetPay](https://github.com/thephpleague/omnipay-targetpay) | omnipay/targetpay | [Alexander Deruwe](https://github.com/aderuwe)
 [UnionPay](https://github.com/lokielse/omnipay-unionpay) | omnipay/lokielse-unionpay | [Loki Else](https://github.com/lokielse)
+[WeChat](https://github.com/labs7in0/omnipay-wechat) | labs7in0/omnipay-wechat | [7IN0's Labs](https://github.com/labs7in0)
 [WechatPay](https://github.com/lokielse/omnipay-wechatpay) | lokielse/omnipay-wechatpay | [Loki Else](https://github.com/lokielse)
 [WePay](https://github.com/Collizo4sky/omnipay-wepay) | Collizo4sky/omnipay-wepay | [Agbonghama Collins](https://github.com/Collizo4sky)
 [Wirecard](https://github.com/igaponov/omnipay-wirecard) | igaponov/omnipay-wirecard | [Igor Gaponov](https://github.com/igaponov)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Gateway | Composer Package | Maintainer
 [Stripe](https://github.com/thephpleague/omnipay-stripe) | omnipay/stripe | [Kayla Daniels](https://github.com/kayladnls)
 [TargetPay](https://github.com/thephpleague/omnipay-targetpay) | omnipay/targetpay | [Alexander Deruwe](https://github.com/aderuwe)
 [UnionPay](https://github.com/lokielse/omnipay-unionpay) | omnipay/lokielse-unionpay | [Loki Else](https://github.com/lokielse)
-[WeChat](https://github.com/labs7in0/omnipay-wechat) | labs7in0/omnipay-wechat | [7IN0's Labs](https://github.com/labs7in0)
+[WechatPay](https://github.com/lokielse/omnipay-wechatpay) | lokielse/omnipay-wechatpay | [Loki Else](https://github.com/lokielse)
 [WePay](https://github.com/Collizo4sky/omnipay-wepay) | Collizo4sky/omnipay-wepay | [Agbonghama Collins](https://github.com/Collizo4sky)
 [Wirecard](https://github.com/igaponov/omnipay-wirecard) | igaponov/omnipay-wirecard | [Igor Gaponov](https://github.com/igaponov)
 [WorldPay](https://github.com/thephpleague/omnipay-worldpay) | omnipay/worldpay | [Kayla Daniels](https://github.com/kayladnls)

--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,7 @@
         "justinbusschau/omnipay-secpay": "SecPay",
         "lokielse/omnipay-alipay": "Alipay",
         "lokielse/omnipay-unionpay": "UnionPay",
+        "lokielse/omnipay-wechatpay": "WechatPay",
         "mfauveau/omnipay-nmi": "Network Merchants Inc. (NMI)",
         "mfauveau/omnipay-pacnet": "Pacnet",
         "omnipay/payu": "PayU",


### PR DESCRIPTION
I'm @lokielse , the author of `lokielse/omnipay-alipay` and `lokielse/omnipay-unionpay`

This is a another gateway `lokielse/omnipay-wechapay` for Wechat Payment

 I replace the original `labs7in0/omnipay-wechat` with `lokielse/omnipay-wechapay` for it is only few part of wechat payment. 

The package `lokielse/omnipay-wechatpay` provides more gateways and methods for wechat payment.
