### PR TITLE
[3.0] Use status for completed/cancelled/pending

### DIFF
--- a/src/Common/Message/AbstractResponse.php
+++ b/src/Common/Message/AbstractResponse.php
@@ -69,13 +69,30 @@ abstract class AbstractResponse implements ResponseInterface
     }
 
     /**
-     * Is the response successful?
+     * Is the response completed?
+     *
+     * @return boolean
+     */
+    abstract public function isCompleted();
+
+    /**
+     * Get the response status
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        return ResponseInterface::STATUS_UNDEFINED;
+    }
+
+    /**
+     * Is the response pending?
      *
      * @return boolean
      */
     public function isPending()
     {
-        return false;
+        return $this->getStatus() === ResponseInterface::STATUS_PENDING;
     }
 
     /**
@@ -105,7 +122,7 @@ abstract class AbstractResponse implements ResponseInterface
      */
     public function isCancelled()
     {
-        return false;
+        return $this->getStatus() === ResponseInterface::STATUS_CANCELLED;
     }
 
     /**

--- a/src/Common/Message/ResponseInterface.php
+++ b/src/Common/Message/ResponseInterface.php
@@ -15,6 +15,14 @@ namespace League\Omnipay\Common\Message;
  */
 interface ResponseInterface extends MessageInterface
 {
+    const STATUS_AUTHORIZED = 'authorized';
+    const STATUS_CANCELLED = 'cancelled';
+    const STATUS_CAPTURED = 'captured';
+    const STATUS_EXPIRED = 'expired';
+    const STATUS_PENDING = 'pending';
+    const STATUS_REFUNDED = 'refunded';
+    const STATUS_UNDEFINED = 'undefined';
+
     /**
      * Get the original request which generated this response
      *
@@ -23,11 +31,11 @@ interface ResponseInterface extends MessageInterface
     public function getRequest();
 
     /**
-     * Is the response successful?
+     * Is the transaction completed?
      *
      * @return boolean
      */
-    public function isSuccessful();
+    public function isCompleted();
 
     /**
      * Does the response require a redirect?
@@ -56,6 +64,13 @@ interface ResponseInterface extends MessageInterface
      * @return null|string A response code from the payment gateway
      */
     public function getCode();
+
+    /**
+     * Status
+     *
+     * @return null|string The status of the response
+     */
+    public function getStatus();
 
     /**
      * Gateway Reference

--- a/tests/Common/Message/AbstractResponseTest.php
+++ b/tests/Common/Message/AbstractResponseTest.php
@@ -99,7 +99,7 @@ class AbstractResponseTest_MockRedirectResponse extends AbstractResponse impleme
         return false;
     }
 
-    public function isSuccessful()
+    public function isCompleted()
     {
         return false;
     }


### PR DESCRIPTION
- Renames `isSuccessful` to `isCompleted` for consistency.
- Adds common statuses to the ResponseInterface
- Use status to set `isCompleted`/`isCancelled`,`isPending`.

Thoughts:
- isRedirect isn't an actual status so not sure if needed. Needs extra logic for the redirect url anyways.
- isCompleted could also be set from the status, but this differs from each type of request (capture, authorize, void etc).
- Do we need more status codes? Eg. `void`, `failed`, `new`/`redirect` (between redirect and return?) etc.

(Closes #275, closes #281)
cc @aimeos @judgej