### PR TITLE
Add locale Value Object

### DIFF
--- a/src/Common/Locale.php
+++ b/src/Common/Locale.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Locale class
+ */
+
+namespace League\Omnipay\Common;
+
+use InvalidArgumentException;
+
+/**
+ * Locale class
+ *
+ * This class abstracts certain functionality around locales in the Omnipay system.
+ */
+final class Locale
+{
+    /** @var  string */
+    private $primaryLanguage;
+
+    /** @var  string */
+    private $region;
+
+    /**
+     * Create a new Currency object
+     *
+     * @param string $primaryLanguage
+     * @param string $region
+     *
+     */
+    public function __construct($primaryLanguage, $region = null)
+    {
+        $this->primaryLanguage = strtolower($primaryLanguage);
+        $this->region = strtolower($region);
+    }
+
+    /**
+     * Get the full locale
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->primaryLanguage . ($this->region ? '-' . $this->region : '');
+    }
+
+    /**
+     * Get the primary language
+     *
+     * @return string
+     */
+    public function getPrimaryLanguage()
+    {
+        return $this->primaryLanguage;
+    }
+
+    /**
+     * Get the region
+     *
+     * @return string
+     */
+    public function getRegion()
+    {
+        return $this->region ?: null;
+    }
+
+    /**
+     * Get the locale, based on a string
+     *
+     * @param string $locale
+     * @return static
+     */
+    public static function parse($locale)
+    {
+        $primaryLanguage = $locale;
+        $region = null;
+
+        $locale = str_replace('_', '-', $locale);
+        if (strpos($locale, '-') !== false) {
+            list($primaryLanguage, $region) = explode('-', $locale);
+        }
+
+        return new static($primaryLanguage, $region);
+    }
+
+    public function __toString()
+    {
+        return $this->getLocale();
+    }
+}

--- a/src/Common/Message/AbstractRequest.php
+++ b/src/Common/Message/AbstractRequest.php
@@ -14,6 +14,7 @@ use League\Omnipay\Common\Exception\InvalidRequestException;
 use League\Omnipay\Common\Exception\RuntimeException;
 use League\Omnipay\Common\Helper;
 use League\Omnipay\Common\ItemBag;
+use League\Omnipay\Common\Locale;
 use League\Omnipay\Common\ParameterBag;
 use League\Omnipay\Common\ParameterizedInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -345,6 +346,36 @@ abstract class AbstractRequest implements RequestInterface, ParameterizedInterfa
     public function setAmount($value)
     {
         return $this->setParameter('amount', $value);
+    }
+
+    /**
+     * Get the request locale.
+     *
+     * @return Locale
+     */
+    public function getLocale()
+    {
+        return $this->getParameter('locale');
+    }
+
+    /**
+     * Set the request Locale
+     *
+     * @param  string|Locale $value
+     * @throws InvalidRequestException
+     * @return AbstractRequest Provides a fluent interface
+     */
+    public function setLocale($value)
+    {
+        if (is_string($value)) {
+            $value = Locale::parse($value);
+        }
+
+        if (! $value instanceof Locale) {
+            throw new InvalidRequestException('A valid Locale is required');
+        }
+
+        return $this->setParameter('locale', $value);
     }
 
     /**

--- a/tests/Common/LocaleTest.php
+++ b/tests/Common/LocaleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace League\Omnipay\Common;
+
+use League\Omnipay\Tests\TestCase;
+
+class LocaleTest extends TestCase
+{
+
+    public function testConstruct()
+    {
+        $locale = new Locale('en', 'us');
+        $this->assertSame('en-us', $locale->getLocale());
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertSame('us', $locale->getRegion());
+        $this->assertSame('en-us', (string) $locale);
+    }
+
+    public function testConstructWithoutRegion()
+    {
+        $locale = new Locale('en');
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertNull($locale->getRegion());
+    }
+
+    public function testParse()
+    {
+        $locale = Locale::parse('en-us');
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertSame('us', $locale->getRegion());
+    }
+
+    public function testParseUnderscore()
+    {
+        $locale = Locale::parse('en_us');
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertSame('us', $locale->getRegion());
+    }
+
+    public function testParseWithoutRegion()
+    {
+        $locale = Locale::parse('en');
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertNull($locale->getRegion());
+    }
+
+    public function testLowercase()
+    {
+        $locale = Locale::parse('En-US');
+        $this->assertSame('en-us', $locale->getLocale());
+        $this->assertSame('en', $locale->getPrimaryLanguage());
+        $this->assertSame('us', $locale->getRegion());
+    }
+}

--- a/tests/Common/Message/AbstractRequestTest.php
+++ b/tests/Common/Message/AbstractRequestTest.php
@@ -156,6 +156,15 @@ class AbstractRequestTest extends TestCase
         $this->assertSame('EUR', $this->request->getAmount()->getCurrency()->getCode());
     }
 
+    public function testLocale()
+    {
+        $this->assertSame($this->request, $this->request->setLocale('en-us'));
+
+        $locale = $this->request->getLocale();
+        $this->assertInstanceOf('\League\Omnipay\Common\Locale', $locale);
+        $this->assertSame('en-us', $locale->getLocale());
+    }
+
     public function testDescription()
     {
         $this->assertSame($this->request, $this->request->setDescription('Cool product'));


### PR DESCRIPTION
Fixes #279

Adds Value Object that parses simple locales and provides an unified interface for the Locale.
Naming is based on http://php.net/manual/en/locale.getprimarylanguage.php and http://php.net/manual/en/locale.getregion.php
Just uses region and primary language.