### PR TITLE
Adding lemonstand/omnipay-vantiv to list of gateways.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Gateway | Composer Package | Maintainer
 [Stripe](https://github.com/thephpleague/omnipay-stripe) | omnipay/stripe | [Kayla Daniels](https://github.com/kayladnls)
 [TargetPay](https://github.com/thephpleague/omnipay-targetpay) | omnipay/targetpay | [Alexander Deruwe](https://github.com/aderuwe)
 [UnionPay](https://github.com/lokielse/omnipay-unionpay) | lokielse/omnipay-unionpay | [Loki Else](https://github.com/lokielse)
+[Vantiv](https://github.com/lemonstand/omnipay-vantiv) | lemonstand/omnipay-vantiv | [LemonStand](https://github.com/lemonstand)
 [Veritrans](https://github.com/andylibrian/omnipay-veritrans) | andylibrian/omnipay-veritrans | [Andy Librian](https://github.com/andylibrian)
 [WebMoney](https://github.com/dercoder/omnipay-webmoney) | dercoder/omnipay-webmoney | [Alexander Fedra](https://github.com/dercoder)
 [WeChat](https://github.com/labs7in0/omnipay-wechat) | labs7in0/omnipay-wechat | [7IN0's Labs](https://github.com/labs7in0)


### PR DESCRIPTION
See: [Vantiv/Litle & Co's Developer Portal](https://litleco.github.io//)

Litle & Co was a Payment Processor acquired by Vantiv. This driver integrates with that services.