### PR TITLE
Upgrade to guzzle 6.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.6",
         "alcohol/iso4217": "^3.1",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.2.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1.0"
     },


### PR DESCRIPTION
For security reasons, see https://github.com/guzzle/guzzle/releases/tag/6.2.1