### PR TITLE
Remove instructions to make a gateway official

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ it is officially supported. You should use your own username as the vendor prefi
 For example, if your GitHub username was `santa`, and you were implementing the `giftpay`
 payment library, a good name for your composer package would be `santa/omnipay-giftpay`.
 
-If you want to transfer your gateway to the `omnipay` GitHub organization and add it
-to the list of officially supported gateways, please open a pull request on the
-[omnipay/common](https://github.com/thephpleague/omnipay-common) package. Before new gateways will
-be accepted, they must have 100% unit test code coverage, and follow the conventions
-and code style used in other Omnipay gateways.
-
 ## Installation
 
 Omnipay is installed via [Composer](https://getcomposer.org/). For most uses, you will need to require an individual gateway:


### PR DESCRIPTION
Because according to @barryvdh, making gateways official isn't a thing anymore: https://github.com/thephpleague/omnipay-common/pull/124#issuecomment-254435039

Should probably remove the "Make your driver official" section on http://omnipay.thephpleague.com/gateways/build-your-own/ as well.