### PR TITLE
[3.0] Use container to resolve dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
         "php": ">=5.6",
         "guzzlehttp/guzzle": "^6",
         "omnipay/common": "^3@dev",
-        "zendframework/zend-diactoros": "^1.1"
+        "zendframework/zend-diactoros": "^1.1",
+        "league/container": "^2.2",
+        "container-interop/container-interop": "^1.1"
     },
     "require-dev": {
         "omnipay/tests": "^3@dev"

--- a/src/Container/HttpClientServiceProvider.php
+++ b/src/Container/HttpClientServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace League\Omnipay\Container;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use League\Omnipay\Common\Http\ClientInterface;
+use League\Omnipay\Common\Http\GuzzleClient;
+
+class HttpClientServiceProvider extends AbstractServiceProvider
+{
+    protected $provides = [
+        ClientInterface::class,
+    ];
+
+    public function register()
+    {
+        $this->getContainer()->add(ClientInterface::class, GuzzleClient::class);
+    }
+}

--- a/src/Container/ServerRequestServiceProvider.php
+++ b/src/Container/ServerRequestServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace League\Omnipay\Container;
+
+use League\Container\ServiceProvider\AbstractServiceProvider;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\ServerRequestFactory;
+
+class ServerRequestServiceProvider extends AbstractServiceProvider
+{
+    protected $provides = [
+        ServerRequestInterface::class,
+    ];
+
+    public function register()
+    {
+        $this->getContainer()->add(ServerRequestInterface::class, function () {
+            return ServerRequestFactory::fromGlobals();
+        }, true);
+    }
+}

--- a/src/GatewayFactory.php
+++ b/src/GatewayFactory.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Omnipay class
+ */
+
+namespace League\Omnipay;
+
+use Interop\Container\ContainerInterface;
+use League\Omnipay\Common\GatewayInterface;
+use League\Omnipay\Common\Http\GuzzleClient;
+use Psr\Http\Message\ServerRequestInterface;
+use League\Omnipay\Common\Http\ClientInterface;
+use League\Omnipay\Common\Exception\RuntimeException;
+use Zend\Diactoros\ServerRequestFactory;
+
+class GatewayFactory
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Create a new gateway instance
+     *
+     * @param string $class Gateway name
+     * @throws RuntimeException                 If no such gateway is found
+     * @return GatewayInterface                 An object of class $class is created and returned
+     */
+    public function create($class)
+    {
+        try {
+            $gateway = $this->container->get($class);
+        } catch (\Exception $e) {
+            throw new RuntimeException(sprintf("Cannot create gateway %s: %s", $class, $e->getMessage()), 0, $e);
+        }
+
+        if (! $gateway instanceof GatewayInterface) {
+            throw new RuntimeException(sprintf("Gateway must implement %s interface", GatewayInterface::class));
+        }
+
+        return $gateway;
+    }
+}

--- a/tests/OmnipayTest.php
+++ b/tests/OmnipayTest.php
@@ -2,6 +2,7 @@
 
 namespace League\Omnipay;
 
+use Interop\Container\ContainerInterface;
 use League\Omnipay\Common\AbstractGateway;
 use League\Omnipay\Common\Http\ClientInterface;
 use Mockery as m;
@@ -10,25 +11,8 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class OmnipayTest extends TestCase
 {
-    public static function setUpBeforeClass()
-    {
-        m::mock('alias:League\\Omnipay\\SpareChange\\TestGateway');
-    }
 
-    public function testCreate()
-    {
-        $httpClient = m::mock(ClientInterface::class);
-        $httpRequest = m::mock(ServerRequestInterface::class);
-
-        /** @var OmnipayTest_TestGateway $gateway */
-        $gateway = Omnipay::create(OmnipayTest_TestGateway::class, $httpClient, $httpRequest);
-
-        $this->assertInstanceOf(OmnipayTest_TestGateway::class, $gateway);
-        $this->assertInstanceOf(ClientInterface::class, $gateway->getProtectedHttpClient());
-        $this->assertInstanceOf(ServerRequestInterface::class, $gateway->getProtectedHttpRequest());
-    }
-
-    public function testCreateDefaults()
+    public function testCreateGateway()
     {
         /** @var OmnipayTest_TestGateway $gateway */
         $gateway = Omnipay::create(OmnipayTest_TestGateway::class);
@@ -38,9 +22,16 @@ class OmnipayTest extends TestCase
         $this->assertInstanceOf(ServerRequestInterface::class, $gateway->getProtectedHttpRequest());
     }
 
+    public function testGetContainer()
+    {
+        $container = Omnipay::getContainer();
+
+        $this->assertInstanceOf(ContainerInterface::class, $container);
+    }
+
     /**
      * @expectedException \League\Omnipay\Common\Exception\RuntimeException
-     * @expectedExceptionMessage Class 'Invalid' not found
+     * @expectedExceptionMessage Cannot create gateway Invalid
      */
     public function testCreateInvalid()
     {


### PR DESCRIPTION
Modified from #368 

I split the package back to Omnipay and Omnipay/Common. This package now has the GatewayFactory and this PR brings container here.

This means that the omnipay-common doesn't need any dependencies from the Container, Guzzle or Diactoros, but just the interfaces. Gateways can depend on that, while end-users can use this package for easier usage. Frameworks can depend on the omnipay-common using their own container/whatever they want.

Thoughts? Downside is that it's harder to pass your own clients, because you need to use the container.
