### PR TITLE
Add academe/omnipay-wirecard

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Gateway | Composer Package | Maintainer
 [WechatPay](https://github.com/lokielse/omnipay-wechatpay) | lokielse/omnipay-wechatpay |  [Loki Else](https://github.com/lokielse)
 [WePay](https://github.com/collizo4sky/omnipay-wepay) | collizo4sky/omnipay-wepay | [Agbonghama Collins](https://github.com/collizo4sky)
 [Wirecard](https://github.com/igaponov/omnipay-wirecard) | igaponov/omnipay-wirecard | [Igor Gaponov](https://github.com/igaponov)
+[Wirecard](https://github.com/academe/omnipay-wirecard) | academe/omnipay-wirecard | [Jason Judge](https://github.com/judgej)
 [WorldPay](https://github.com/thephpleague/omnipay-worldpay) | omnipay/worldpay | [Omnipay](https://github.com/thephpleague/omnipay)
 [WorldPay XML Direct](https://github.com/teaandcode/omnipay-worldpay-xml) | teaandcode/omnipay-worldpay-xml | [Dave Nash](https://github.com/teaandcode)
 [Yandex.Money](https://github.com/aTastyCookie/yandexmoney_omnipay) | aTastyCookie/yandexmoney_omnipay | [Roman Ananyev](https://github.com/aTastyCookie/)


### PR DESCRIPTION
This is an alternative to the existing igaponov/omnipay-wirecard, more
suited to automated configuration in frameworks. Just different - use
the one that most closely fits yoru needs.