### PR TITLE
Added note on initializing gateway parameters

### DIFF
--- a/api/authorizing.md
+++ b/api/authorizing.md
@@ -48,3 +48,16 @@ To summarize the various parameters you have available to you:
 * Gateway settings (e.g. username and password) are set directly on the gateway. These settings apply to all payments, and generally you will store these in a configuration file or in the database.
 * Method options are used for any payment-specific options, which are not set by the customer. For example, the payment `amount`, `currency`, `transactionId` and `returnUrl`.
 * CreditCard parameters are data which the user supplies. For example, you want the user to specify their `firstName` and `billingCountry`, but you don't want a user to specify the payment `currency` or `returnUrl`.
+
+The parameters can be set in two ways:
+
+* As an array when creating the request object, as shown above.
+* Using setter methods on the request object following a similar naming convention.
+
+For example, the card and amount can be set after the `authorize` request has been created like this:
+
+```php
+$request = $gateway->authorize(['returnUrl' => 'https://www.example.com/return']);
+$request->setCard($card);
+$request->setAmount('10.00');
+```

--- a/gateways/configuring.md
+++ b/gateways/configuring.md
@@ -22,6 +22,17 @@ $gateway->setUsername('adrian');
 $gateway->setPassword('12345');
 ~~~
 
+Alternatively, multiple parameters can be initialized at once, directly from data:
+
+~~~ php
+...
+$gateway->initialize([
+    'username' => 'adrian',
+    'password' => '12345',
+]);
+~~~
+
+
 ## Gateway settings
 
 Most settings are gateway specific. If you need to query a gateway to get a list of available settings, you can call `getDefaultParameters()`:

--- a/gateways/configuring.md
+++ b/gateways/configuring.md
@@ -32,6 +32,8 @@ $gateway->initialize([
 ]);
 ~~~
 
+Setting parameters this way will start by taking the default parameters as a base,
+and then merging your supplied parameters over the top.
 
 ## Gateway settings
 


### PR DESCRIPTION
When using multiple gateways, initializing from data like this, rather
than through explicit driver-specific methods, can make the code a lot
more generic.