### PR TITLE
Add support for cloudbanking

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Gateway | Composer Package | Maintainer
 [CardGate](https://github.com/cardgate/omnipay-cardgate) | cardgate/omnipay-cardgate | [CardGate](https://github.com/cardgate)
 [CardSave](https://github.com/thephpleague/omnipay-cardsave) | omnipay/cardsave | [Omnipay](https://github.com/thephpleague/omnipay)
 [Checkout.com](https://github.com/fotografde/omnipay-checkoutcom) | fotografde/checkoutcom | [fotograf.de](https://github.com/fotografde)
+[CloudBanking](https://github.com/spsingh/omnipay-cloudbanking) | cloudbanking/omnipay-cloudbanking | [Cloudbanking](http://cloudbanking.com.au/)
 [Coinbase](https://github.com/thephpleague/omnipay-coinbase) | omnipay/coinbase | [Omnipay](https://github.com/thephpleague/omnipay)
 [CoinGate](https://github.com/coingate/omnipay-coingate) | coingate/omnipay-coingate | [CoinGate](https://github.com/coingate)
 [Creditcall](https://github.com/meebio/omnipay-creditcall) | meebio/omnipay-creditcall | [John Jablonski](https://github.com/jan-j)


### PR DESCRIPTION
The Cloudbanking gateway information can be found at
http://cloudbanking.com.au
And the api details at
https://api.cloudbanking.com.au/
The actual repo is at the below address.
https://github.com/spsingh/omnipay-cloudbanking.git