### PR TITLE
Fix Common/CreditCard.php link

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ gateway (other than by the methods they support).
 
 ## Credit Card / Payment Form Input
 
-User form input is directed to an [CreditCard](https://github.com/thephpleague/omnipay-common/blob/master/src/Omnipay/Common/CreditCard.php)
+User form input is directed to an [CreditCard](https://github.com/thephpleague/omnipay-common/blob/master/src/Common/CreditCard.php)
 object. This provides a safe way to accept user input.
 
 The `CreditCard` object has the following fields:


### PR DESCRIPTION
The link to Common/CreditCard.php was outdated and this commit 
fixes it.