### PR TITLE
Add a Paysera gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Gateway | 2.x | 3.x | Composer Package | Maintainer
 [PAYONE](https://github.com/academe/omnipay-payone) | ✓ | ✓ | academe/omnipay-payone | [Jason Judge](https://github.com/judgej)
 [Paysafecard](https://github.com/dercoder/omnipay-paysafecard) | ✓ | - | dercoder/omnipay-paysafecard | [Alexander Fedra](https://github.com/dercoder)
 [Paysera](https://github.com/povils/omnipay-paysera) | ✓ | - | povils/omnipay-paysera | [Povils](https://github.com/povils)
+[Paysera](https://github.com/semyonchetvertnyh/omnipay-paysera) | - | ✓ | semyonchetvertnyh/omnipay-paysera | [Semyon Chetvertnyh](https://github.com/semyonchetvertnyh)
 [PaySimple](https://github.com/dranes/omnipay-paysimple) | ✓ | - | dranes/omnipay-paysimple | [Dranes](https://github.com/dranes)
 [PaySsion](https://github.com/InkedCurtis/omnipay-payssion) | ✓ | - | inkedcurtis/omnipay-payssion | [Curtis](https://github.com/inkedcurtis)
 [PayTrace](https://github.com/iddqdidkfa/omnipay-paytrace) | ✓ | - | softcommerce/omnipay-paytrace | [Oleg Ilyushyn](https://github.com/iddqdidkfa)


### PR DESCRIPTION
This PR adds a link to [Paysera](https://paysera.com) gateway package that supports Omnipay v3+.