### PR TITLE
Allow guzzle6 v2 adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^5.6|^7",
         "omnipay/common": "^3",
-        "php-http/guzzle6-adapter": "^1.1"
+        "php-http/guzzle6-adapter": "^1.1|^2"
     },
     "require-dev": {
         "omnipay/tests": "^3"


### PR DESCRIPTION
V2 supports httplug v2 + psr-18. Allowing v1 for now (for php < 7.1 support) but we might remove it in the future.