### PR TITLE
Add Affirm driver for Omnipay v2 & v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Gateway | 2.x | 3.x | Composer Package | Maintainer
 [2Checkout Improved](https://github.com/collizo4sky/omnipay-2checkout) | ✓ | - | collizo4sky/omnipay-2checkout | [Agbonghama Collins](https://github.com/collizo4sky)
 [Acapture (PayVision)](https://github.com/queueup-dev/omnipay-acapture) | ✓ | - | qup/omnipay-acapture | [Niels de Vries](https://github.com/niels-qup)
 [Adyen](https://github.com/academe/omnipay-adyen) | - | ✓ | academe/omnipay-adyen | [Jason Judge](https://github.com/judgej)
+[Affirm](https://github.com/eduardlleshi/omnipay-affirm) | ✓ | ✓ | eduardlleshi/omnipay-affirm | [Eduard Lleshi](https://github.com/eduardlleshi)
 [Agms](https://github.com/agmscode/omnipay-agms) | ✓ | - | agmscode/omnipay-agms | [Maanas Royy](https://github.com/maanas)
 [Alipay(Global)](https://github.com/lokielse/omnipay-global-alipay) | ✓ | ✓ | lokielse/omnipay-global-alipay | [Loki Else](https://github.com/lokielse)
 [Alipay](https://github.com/lokielse/omnipay-alipay) | ✓ | ✓ | lokielse/omnipay-alipay | [Loki Else](https://github.com/lokielse)


### PR DESCRIPTION
Adds [Affirm](https://www.affirm.com/) driver for Omnipay v2 & v3